### PR TITLE
fix: fix the web application manifest

### DIFF
--- a/assets/app.webmanifest
+++ b/assets/app.webmanifest
@@ -1,5 +1,7 @@
 {
+  "name": "Ariel OS",
+  "background_color": "#eee",
   "icons": [
-    { "src": "/android-512.png", "type": "image/png", "sizes": "512x512" }
+    { "src": "/favicons/android-512.png", "type": "image/png", "sizes": "512x512" }
   ]
 }


### PR DESCRIPTION
Tested it on my (Android) phone with Firefox: the manifest is fetched and used to create a home screen icon and label, and the background color is used as appriopriate.