### PR TITLE
feat: deploy to tatooine rather than GitHub pages

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -9,12 +9,6 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
@@ -41,9 +35,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: Setup Pages
-        id: pages
-        uses: actions/configure-pages@v5
       - name: Install Node.js dependencies
         run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
       - name: Build with Hugo
@@ -54,19 +45,13 @@ jobs:
           hugo \
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Deploy to the project's server
+        uses: burnett01/rsync-deployments@v8
         with:
-          path: ./public
-
-  # Deployment job
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          switches: -avzr --delete
+          path: public/
+          remote_path: /
+          remote_host: ${{ secrets.SSH_GUIDES_REMOTE_HOST }}
+          remote_port: ${{ secrets.SSH_GUIDES_REMOTE_PORT }}
+          remote_user: ${{ secrets.SSH_GUIDES_REMOTE_USER }}
+          remote_key: ${{ secrets.SSH_GUIDES_PRIVATE_KEY }}


### PR DESCRIPTION
GitHub pages have been a hassle to debug: They wouldn't start getting a Let's Encrypt certificate even though all A/AAAA records were present, and wouldn't give a sensible error message other than "we don't think it's set up right".

As tatooine was a convenient stopgap measure intermittently anyway, we're now just pushing there regularly.