### PR TITLE
chore: disable kinds we do not use

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -3,6 +3,8 @@ languageCode = 'en-us'
 title = 'Ariel OS'
 theme = 'ariel-os'
 
+disableKinds = ["taxonomy", "taxonomyTerm", "RSS"]
+
 [menus]
   [[menus.main]]
     name = 'Learn'


### PR DESCRIPTION
There are a few generated files that don't have sensible content and/or are not in the designed URI paths where we want them (cf. https://github.com/ariel-os/ariel-os-cool-uris/pull/2); disabling them until we're sure we want them.