### PR TITLE
docs: fix grammar error in v0.3.0 blog post

### DIFF
--- a/content/blog/ariel-os-0.3.0.md
+++ b/content/blog/ariel-os-0.3.0.md
@@ -62,7 +62,7 @@ async fn main(peripherals: pins::Peripherals) {
 
 After a few rounds of design, the new sensor abstraction API is now available for you to try out!
 
-All sensors using this system are can be accessed through a central registry and a universal API.
+All sensors using this system can be accessed through a central registry and a universal API.
 Want to know the current temperature? Just select any sensor in the registry that has the category `Temperature`.
 
 ```rust


### PR DESCRIPTION
Deleted an extra word in a sentence to make it grammatical correct.