### PR TITLE
feat: add community day pages for the 2026 edition

### DIFF
--- a/content/1ad/_index.md
+++ b/content/1ad/_index.md
@@ -1,0 +1,9 @@
++++
+date = '2026-04-22T15:02:45+01:00'
+draft = false
+layout = 'community-day-2026'
+type = 'page'
+title = "Ariel OS 2026 Community Day"
++++
+
+Lorem ipsum dolor sit amet.

--- a/content/1ad/call-for-contributions/index.md
+++ b/content/1ad/call-for-contributions/index.md
@@ -1,0 +1,9 @@
++++
+date = '2026-04-22T14:02:45+01:00'
+draft = false
+layout = 'community-day-2026'
+type = 'page'
+title = "Call For Contributions — 2026 Community Day"
++++
+
+Lorem ipsum dolor sit amet.

--- a/content/1ad/register/index.md
+++ b/content/1ad/register/index.md
@@ -1,0 +1,9 @@
++++
+date = '2026-04-22T14:02:45+01:00'
+draft = false
+layout = 'community-day-2026'
+type = 'page'
+title = "Register — 2026 Community Day"
++++
+
+Lorem ipsum dolor sit amet.

--- a/content/1ad/schedule/index.md
+++ b/content/1ad/schedule/index.md
@@ -1,0 +1,9 @@
++++
+date = '2026-04-22T14:02:45+01:00'
+draft = false
+layout = 'community-day-2026'
+type = 'page'
+title = "Schedule — 2026 Community Day"
++++
+
+Lorem ipsum dolor sit amet.

--- a/content/1ad/venue/index.md
+++ b/content/1ad/venue/index.md
@@ -1,0 +1,9 @@
++++
+date = '2026-04-22T14:02:45+01:00'
+draft = false
+layout = 'community-day-2026'
+type = 'page'
+title = "Venue — 2026 Community Day"
++++
+
+Lorem ipsum dolor sit amet.

--- a/hugo.toml
+++ b/hugo.toml
@@ -26,6 +26,31 @@ disableKinds = ["taxonomy", "taxonomyTerm", "RSS"]
     url = 'https://github.com/ariel-os/ariel-os'
     weight = 40
 
+  [[menus.community-day-2026]]
+    name = 'Schedule'
+    url = '/1ad/schedule'
+    weight = 10
+
+  [[menus.community-day-2026]]
+    name = 'Register'
+    url = '/1ad/register'
+    weight = 20
+
+  [[menus.community-day-2026]]
+    name = 'Call for contributions'
+    url = '/1ad/call-for-contributions'
+    weight = 30
+
+  [[menus.community-day-2026]]
+    name = 'Venue'
+    url = '/1ad/venue'
+    weight = 40
+
+  [[menus.community-day-2026]]
+    name = 'About'
+    url = '/1ad'
+    weight = 50
+
 [markup]
   [markup.highlight]
     style = "bw"

--- a/themes/ariel-os/layouts/page/community-day-2026.html
+++ b/themes/ariel-os/layouts/page/community-day-2026.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="{{ site.Language.LanguageCode }}" dir="{{ or site.Language.LanguageDirection `ltr` }}">
+<head>
+  {{ partial "head.html" . }}
+</head>
+<body>
+  <!-- TODO: deduplicate with the header used elsewhere -->
+  <header class="nav-bar">
+    <div class="max-w-4xl mx-auto">
+      <div class="hidden items-center justify-between md-flex">
+        <div>
+          <a href="/">{{ site.Title }}</a>
+        </div>
+        {{ partial "menu.html" (dict "menuID" "community-day-2026" "page" .) }}
+      </div>
+      <div class="nav-menu md-hidden">
+        <details>
+          <summary class="flex items-center justify-between list-none">
+            <a href="/">{{ site.Title }}</a>
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-list" viewBox="0 0 16 16">
+              <path fill-rule="evenodd" d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5m0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5m0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5"/>
+            </svg>
+          </summary>
+          {{ partial "menu.html" (dict "menuID" "community-day-2026" "page" .) }}
+        </details>
+      </div>
+    </div>
+  </header>
+  <main>
+    <article class="max-w-3xl mx-auto px-10 py-20">
+      <header>
+        <h1 class="mb-3">{{ .Title }}</h1>
+      </header>
+
+      {{ .Content }}
+    </article>
+  </main>
+  <footer>
+    {{ partial "footer.html" . }}
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
For now this only does the basic setup of introducing a set of pages for the 2026 Community Day, and adds a dedicated layout that replaces the regular nav bar.

The actual content now needs to be added; page titles can be modified as needed.

---

The website can be rendered locally using `hugo serve`.