### PR TITLE
feat: add blog for the 1AD call for contributions

### DIFF
--- a/content/blog/1ad-cfp.md
+++ b/content/blog/1ad-cfp.md
@@ -1,0 +1,22 @@
++++
+date = '2026-06-08T10:42:43+02:00'
+title = '1AD Call For Contributions'
+# tags = ["1AD"]
++++
+
+On September 1st at Université Grenoble Alpes, Campus de Saint Martin d’Hères,
+we will have our first Ariel OS Community Day.
+
+1AD, the 1st Ariel OS Community Day,
+is a meetup aiming to bring together embedded Rust developers,
+Ariel OS maintainers and Embassy contributors, beginners and experts.
+People interested in the IoT in general and decision makers
+who are considering deploying embedded Rust firmware/software in the near future
+are also very welcome!
+1AD aims not only to inform about latest embedded Rust and Ariel OS developments
+but also to help gather feedback from the community
+so as to better shape the future of Ariel OS.
+
+See the [1AD page](/1ad) for more information
+and the [call for contributions submission page](/1ad/call-for-contributions/)
+if you're interested in presenting your subject!


### PR DESCRIPTION
This adds a blog post for the 1AD, linking to the 1AD site and the call for contributions process.