### PR TITLE
feat: Make call for contributions process a bit simpler

### DIFF
--- a/content/1ad/call-for-contributions/index.md
+++ b/content/1ad/call-for-contributions/index.md
@@ -22,6 +22,33 @@ ariel-os@<b class=hidden>wmerbeowr</b>inria.fr</span>
 ## Submission Deadline
 Let us know as soon as possible but no later than August 1, 2026. If the deadline has passed and you still want to present something, send us an email anyway!
 
+## Submission Template
+
+```
+Submission title: My great talk
+
+## Synopsis
+
+A couple of paragraphs about my talk
+
+## My information
+
+Name: John Doe
+Affiliation: Unknown
+Job title: None
+
+## Biography
+
+A paragraph about myself
+
+## My online social information
+
+- https://github.com/ariel-os/
+- https://floss.social/@ariel/
+- @murdock-ci:matrix.org
+
+```
+
 ## Notification
 We will get in touch soon after your submission. Final notifications will be sent August 8, 2026.
 

--- a/content/1ad/call-for-contributions/index.md
+++ b/content/1ad/call-for-contributions/index.md
@@ -8,7 +8,11 @@ title = "Call For Contributions — 2026 Community Day"
 
 
 ## Submissions
-To submit a talk/demo for 1AD, email us with:
+To submit a talk/demo for 1AD, email us at
+{{< rawhtml >}}
+<span>
+ariel-os@<b class=hidden>wmerbeowr</b>inria.fr</span>
+{{< /rawhtml >}} with:
 
 - the title of your talk/demo
 - a synopsis for your talk/demo (a couple of paragraphs)

--- a/content/1ad/call-for-contributions/index.md
+++ b/content/1ad/call-for-contributions/index.md
@@ -18,7 +18,7 @@ ariel-os@<b class=hidden>wmerbeowr</b>inria.fr</span>
 - a synopsis for your talk/demo (a couple of paragraphs)
 - your name, affiliation, and job title if applicable
 - a short biography (one paragraph suffices)
-- your web surface (e.g. your GitHub, Mastodon, Matrix handles etc.)
+- any online socials to include (e.g. your GitHub, Mastodon, Matrix handles etc.)
 ## Submission Deadline
 Let us know as soon as possible but no later than August 1, 2026. If the deadline has passed and you still want to present something, send us an email anyway!
 

--- a/content/1ad/call-for-contributions/index.md
+++ b/content/1ad/call-for-contributions/index.md
@@ -16,7 +16,7 @@ ariel-os@<b class=hidden>wmerbeowr</b>inria.fr</span>
 
 - the title of your talk/demo
 - a synopsis for your talk/demo (a couple of paragraphs)
-- your name, affiliation, and job title
+- your name, affiliation, and job title if applicable
 - a short biography (one paragraph suffices)
 - your web surface (e.g. your GitHub, Mastodon, Matrix handles etc.)
 ## Submission Deadline


### PR DESCRIPTION
This PR:
- includes the email address directly in the first sentence to lower the submission bar.
- makes the job title optional, as not everyone might be there representing their company.
- renames 'web surface' to 'online socials'.
- adds a template for the submission emails.