### PR TITLE
feat: add community page 

### DIFF
--- a/content/community.md
+++ b/content/community.md
@@ -1,0 +1,43 @@
++++
+date = '2026-06-18T15:54:15+02:00'
+title = 'Community'
+layout = 'legal'
+type = 'page'
+draft = false
++++
+
+Ariel OS is developed by an open community where everyone is welcome to join.
+
+## Meet the Ariel OS Community
+
+You can find the Ariel OS community in the following places:
+
+- {{< ico simple-icons github >}} https://github.com/ariel-os/ariel-os/
+- {{< ico simple-icons mastodon >}} [@ariel@floss.social]
+- {{< ico simple-icons matrix >}} [#ariel-os:matrix.org][matrix room]
+
+## Monthly Meetings
+
+We have a public monthly meeting where we discuss matters around Ariel OS.
+These meetings are open and everyone is welcome to join and add items to the [agenda].
+
+- *When*: First Tuesday of the month at 9.30 am CE(S)T
+- *Where*: [meeting jitsi room]
+
+## Office Hours
+
+We have office hours every first and third thursday of the month.
+The office hours provide a space for live coding, questions and feedback on Ariel OS.
+During the office hours, a number of maintainers are present on our [office hour Jitsi room].
+The office hours are also announced in the [Matrix room].
+
+## Code of Conduct
+
+The [Ariel OS code of conduct] applies to all spaces managed by the Ariel OS community.
+
+[@ariel@floss.social]: https://floss.social/@ariel
+[agenda]: https://pad.riot-os.org/ariel-os-weekly
+[Ariel OS code of conduct]: https://github.com/ariel-os/ariel-os/blob/main/CODE_OF_CONDUCT.md
+[Matrix room]: https://matrix.to/#/#ariel-os:matrix.org
+[meeting jitsi room]: https://meet.jit.si/ariel-os-team-room
+[office hour jitsi room]: https://meet.jit.si/ariel-os-office-hours

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module ariel-os.org/ariel-os/website
+
+go 1.26.2
+
+require (
+	github.com/hugomods/icons/vendors/simple-icons v1.1.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/hugomods/icons v0.6.6 h1:gGlafcBDRP7sSID+tgLcWdog+s/QBj8DIfU+h9tZj1U=
+github.com/hugomods/icons v0.6.6/go.mod h1:cIkSvK6W0q6N4U6n9KGz+QfRWQXAW0INd+1P31gPNGg=
+github.com/hugomods/icons/vendors/simple-icons v1.1.1 h1:ZM+Oi+U3glq+WuVMsoplkQpCnRLd6UU416NZCydtPvw=
+github.com/hugomods/icons/vendors/simple-icons v1.1.1/go.mod h1:ZKdcZ++UGSRnEoaVL+MTth91x4NJRIe8aJOD8oAFcRA=

--- a/hugo.toml
+++ b/hugo.toml
@@ -17,6 +17,11 @@ disableKinds = ["taxonomy", "taxonomyTerm", "RSS"]
     weight = 20
 
   [[menus.main]]
+    name = 'Community'
+    url = '/community'
+    weight = 25
+
+  [[menus.main]]
     name = 'Blog'
     pageRef = '/blog'
     weight = 30
@@ -54,6 +59,10 @@ disableKinds = ["taxonomy", "taxonomyTerm", "RSS"]
 [markup]
   [markup.highlight]
     style = "bw"
+
+[module]
+  [[module.imports]]
+    path = 'github.com/hugomods/icons/vendors/simple-icons'
 
 [params]
   title='Ariel OS'

--- a/themes/ariel-os/assets/css/main.css
+++ b/themes/ariel-os/assets/css/main.css
@@ -105,7 +105,7 @@ h1 {
   font-weight: bold;
 }
 
-article h2, .legal-page h2 {
+:is(article, .legal-page) h2 {
   font-size: 1.5rem;
   font-weight: bold;
   margin-top: 1.8em;
@@ -316,7 +316,7 @@ a.button:focus-visible {
 }
 
 /* code blocks */
-article .highlight pre {
+:is(article, .legal-page) .highlight pre {
   margin: 2rem 0;
   padding: 1.15rem 1.5rem;
   /* JetBrains Mono typeface is available under the SIL Open Font License 1.1 license and can be used free of charge, for both commercial and non-commercial purposes. */
@@ -333,13 +333,13 @@ code {
 
 }
 
-article ul {
+:is(article, .legal-page) ul {
   list-style-position: inside;
   list-style-type: square;
   line-height: 1.7em;
 }
 
-article figure {
+:is(article, .legal-page) figure {
   font-style: italic;
   margin-top: 2.5em;
   margin-bottom: 2.5em;

--- a/themes/ariel-os/assets/css/main.css
+++ b/themes/ariel-os/assets/css/main.css
@@ -87,6 +87,14 @@ a:focus-visible {
   outline: 2px solid var(--dark-color);
 }
 
+em {
+  font-style: italic;
+}
+
+strong {
+  font-weight: bold;
+}
+
 main {
   background: var(--light-color);
   flex: 1;


### PR DESCRIPTION
This adds a community page to the website with basic information about our meetings.

I've also added the CoC and our socials here.

This includes a PR to add a simple-icons module, following instructions from [hugomods](https://blog.hugomods.com/posts/2023/03/how-to-use-hugo-modules/).